### PR TITLE
fix: Use dynamic repo URL for python26-test

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -79,7 +79,7 @@ jobs:
         apt-get install -y build-essential git curl unzip file tar
     - name: clone the repo and checkout pull_request
       run: |
-        git clone https://github.com/RedHatInsights/insights-core.git
+        git clone ${{ github.server_url }}/${{ github.repository }}
         git -C insights-core fetch --no-tags --prune --no-recurse-submodules --depth=1 origin pull/${{ github.ref_name }}:${{ github.head_ref }}
         git -C insights-core checkout ${{ github.head_ref }}
     - name: build setuptools and pip


### PR DESCRIPTION
The harcoded RedHatInsights URL makes the Python 2.6 tests fail when a pull request is created in a fork. Using a dynamic URLs makes the GitHub Action to clone from the fork and use the code in the pull request.

github.repositoryUrl variable can’t be used, because cloning using  git:// protocol fails. HTTPS url is thus composed instead.

### All Pull Requests:

Check all that apply:

* [ ] Have you followed the guidelines in our Contributing document, including the instructions about commit messages?
* [ ] No Sensitive Data in this change?
* [ ] Is this PR to correct an issue?
* [ ] Is this PR an enhancement?

### Complete Description of Additions/Changes:

<!--
Provide complete details of the issue or enhancement. You may link to existing open publicly-accessible issues or enhancement requests that provide these details.

Please do not include links to any websites that are not publicly accessible. You may include non-link reference numbers to help you and your team identify non-public references. 

This information is necessary before your PR can be reviewed.

You may remove this comment.
-->
*Add your description here*
